### PR TITLE
Makefile should respect CC environment variable

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -22,6 +22,9 @@ unless ARGV.any? {|arg| arg.include?('--with-ruby-include') }
 end
 
 require "mkmf"
+
+RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
+
 require "debase/ruby_core_source"
 
 hdrs = proc {


### PR DESCRIPTION
Provides a work around for #12 and #17.

```
brew install gcc
# You may need to unlink apple-gcc42 first...
brew link gcc
CC=/usr/local/bin/gcc-4.9 gem install debase
# If you unlinked apple-gcc42, you may want to unlink gcc and link apple-gcc42.
```