### PR TITLE
update for attach-to-process feature

### DIFF
--- a/ext/breakpoint.c
+++ b/ext/breakpoint.c
@@ -219,9 +219,15 @@ breakpoint_find(VALUE breakpoints, VALUE source, VALUE pos)
 }
 
 extern void
-Init_breakpoint(VALUE mDebase)
+breakpoint_init_variables()
 {
   breakpoint_max = 0;
+}
+
+extern void
+Init_breakpoint(VALUE mDebase)
+{
+  breakpoint_init_variables();
   cBreakpoint = rb_define_class_under(mDebase, "Breakpoint", rb_cObject);
   rb_define_singleton_method(cBreakpoint, "find", Breakpoint_find, 3);
   rb_define_singleton_method(cBreakpoint, "remove", Breakpoint_remove, 2);

--- a/ext/context.c
+++ b/ext/context.c
@@ -345,6 +345,12 @@ Context_stop_frame(VALUE self, VALUE frame)
   return frame;
 }
 
+extern void
+context_init_variables()
+{
+  thnum_current = 0;
+}
+
 /*
  *   Document-class: Context
  *
@@ -373,6 +379,7 @@ Init_context(VALUE mDebase)
   rb_define_method(cContext, "pause", Context_pause, 0);
 
   idAlive = rb_intern("alive?");
+  context_init_variables();
 
   return cContext;
     // rb_define_method(cContext, "suspend", context_suspend, 0);

--- a/ext/debase_internals.h
+++ b/ext/debase_internals.h
@@ -105,4 +105,7 @@ typedef struct
 extern VALUE catchpoint_hit_count(VALUE catchpoints, VALUE exception, VALUE *exception_name);
 extern VALUE breakpoint_find(VALUE breakpoints, VALUE source, VALUE pos);
 extern void Init_breakpoint(VALUE mDebase);
+
+extern void breakpoint_init_variables();
+extern void context_init_variables();
 #endif


### PR DESCRIPTION
made prepare_context public (same as in case of rubinius);
added method for variables initialization (we need to reset them in case of attaching);
changed the way we determine that debug started (now it is `started == 1` instead of `catchpoints != Qnil`;