### PR TITLE
added static for check_stop_frame

### DIFF
--- a/ext/debase_internals.c
+++ b/ext/debase_internals.c
@@ -37,7 +37,7 @@ print_debug(const char *message, ...)
   va_end(ap);
 }
 
-inline int
+static inline int
 check_stop_frame(debug_context_t *context) {
   return context->calced_stack_size == context->stop_frame && context->calced_stack_size >= 0;
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/RUBY-20113
It fixes 'dyld: lazy symbol binding failed: not found: _check_stop_frame'
All other inline methods are static, so...