### PR TITLE
NULL is not needed for methods with no arguments

### DIFF
--- a/ext/debase_internals.c
+++ b/ext/debase_internals.c
@@ -46,7 +46,7 @@ static VALUE
 is_path_accepted(VALUE path) {
   VALUE filter;
   if (file_filter_enabled == Qfalse) return Qtrue;
-  filter = rb_funcall(mDebase, idFileFilter, 0, NULL);
+  filter = rb_funcall(mDebase, idFileFilter, 0);
   return rb_funcall(filter, idAccept, 1, path);
 }
 


### PR DESCRIPTION
This problem has existed for a long time, but up to 2.5.0 ruby version it doesn't affect anything