### PR TITLE
Fix suspensions in debugger source code (replacement for an old, bad fix)

### DIFF
--- a/ext/context.c
+++ b/ext/context.c
@@ -147,6 +147,7 @@ context_create(VALUE thread, VALUE cDebugThread) {
   context->stack_size = 0;
   locations = rb_funcall(thread, rb_intern("backtrace_locations"), 1, INT2FIX(1));
   context->calced_stack_size = locations != Qnil ? RARRAY_LENINT(locations) : 0;
+  context->init_stack_size = -1;
 
   context->stack = NULL;
   context->thnum = ++thnum_current;
@@ -154,6 +155,8 @@ context_create(VALUE thread, VALUE cDebugThread) {
   context->flags = 0;
   context->last_file = NULL;
   context->last_line = -1;
+  context->hit_user_code = 0;
+  context->script_finished = 0;
   context->stop_frame = -1;
   context->thread_pause = 0;
   context->stop_reason = CTX_STOP_NONE;

--- a/ext/debase_internals.c
+++ b/ext/debase_internals.c
@@ -333,7 +333,7 @@ process_line_event(VALUE trace_point, void *data)
   tp = TRACE_POINT;
   path = rb_tracearg_path(tp);
 
-  if(context->stack_size == context->init_stack_size && context->hit_user_code) {
+  if(context->stack_size <= context->init_stack_size && context->hit_user_code) {
     context->script_finished = 1;
   }
   if(context->script_finished) {

--- a/ext/debase_internals.h
+++ b/ext/debase_internals.h
@@ -60,6 +60,9 @@ typedef struct debug_context {
 
   char *last_file;
   int last_line;
+  int init_stack_size;
+  int script_finished;
+  int hit_user_code;
 } debug_context_t;
 
 typedef struct


### PR DESCRIPTION
We don't want to suspend in debugger source code! The most optimal solution is to record a number of service(~debugger) frames and don't handle suspensions in them. After suspension in debugger source code(which was ignored by us) we assume, that for current thread script is over, and we don't need to suspend in it anymore. But we can't disable the whole tracing, because some threads can be active


It should fix ruby-debug-ide tests 