### PR TITLE
comment version-specific test

### DIFF
--- a/lib/debase/version.rb
+++ b/lib/debase/version.rb
@@ -1,3 +1,3 @@
 module Debase
-  VERSION = "0.2.4" unless defined? VERSION
+  VERSION = "0.2.5" unless defined? VERSION
 end


### PR DESCRIPTION
Reuse `#backtrace_each` method from vm_backtrace.c for calculating initial stack size

Fixes https://github.com/denofevil/debase/issues/82