### PR TITLE
compare stack_size only after start_inspector->fill_stack

### DIFF
--- a/lib/debase/version.rb
+++ b/lib/debase/version.rb
@@ -1,3 +1,3 @@
 module Debase
-  VERSION = "0.2.3" unless defined? VERSION
+  VERSION = "0.2.4" unless defined? VERSION
 end


### PR DESCRIPTION
@denofevil It's better to assert all stack-size-specific stuff after `rb_ensure(start_inspector, context_object, stop_inspector, Qnil)`, which will count the exact stack size and frames.