### PR TITLE
Fix debase installation on MacOs system ruby

### DIFF
--- a/ext/attach/extconf.rb
+++ b/ext/attach/extconf.rb
@@ -29,12 +29,8 @@ require "debase/ruby_core_source"
 
 hdrs = proc {
   have_header("vm_core.h") and
-  have_header("iseq.h") and
-  have_header("version.h") and
-  have_header("vm_core.h") and
-  have_header("vm_insnhelper.h") and
-  have_header("vm_core.h") and
-  have_header("method.h")
+  (have_header("iseq.h") or have_header("iseq.h", ["vm_core.h"])) and
+  have_header("version.h")
 }
 
 # Allow use customization of compile options. For example, the

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -29,12 +29,8 @@ require "debase/ruby_core_source"
 
 hdrs = proc {
   have_header("vm_core.h") and
-  have_header("iseq.h") and
-  have_header("version.h") and
-  have_header("vm_core.h") and
-  have_header("vm_insnhelper.h") and
-  have_header("vm_core.h") and
-  have_header("method.h")
+  (have_header("iseq.h") or have_header("iseq.h", ["vm_core.h"])) and
+  have_header("version.h")
 }
 
 # Allow use customization of compile options. For example, the

--- a/lib/debase/version.rb
+++ b/lib/debase/version.rb
@@ -1,3 +1,3 @@
 module Debase
-  VERSION = "0.2.4.1" unless defined? VERSION
+  VERSION = "0.2.5.beta1" unless defined? VERSION
 end

--- a/lib/debase/version.rb
+++ b/lib/debase/version.rb
@@ -1,3 +1,3 @@
 module Debase
-  VERSION = "0.2.5" unless defined? VERSION
+  VERSION = "0.2.4.1" unless defined? VERSION
 end


### PR DESCRIPTION
There are errors with linking `iseq.h`, so we need an explicit dependency on `vm_core.h`
Just like here: https://github.com/tmm1/rblineprof/blob/343cedbb144f4550fa428703ff7eaf51cc3fa8de/ext/extconf.rb#L17