### PR TITLE
Skip debase extconf.rb on non-CRuby

### DIFF
--- a/ext/attach/extconf.rb
+++ b/ext/attach/extconf.rb
@@ -1,4 +1,4 @@
-if defined?(RUBY_ENGINE) && 'rbx' == RUBY_ENGINE
+if defined?(RUBY_ENGINE) && RUBY_ENGINE != 'ruby'
   # create dummy Makefile to indicate success
   f = File.open(File.join(File.dirname(__FILE__), "Makefile"), "w")
   f.write("all:\n\techo all\ninstall:\n\techo installed\n")

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,4 +1,4 @@
-if defined?(RUBY_ENGINE) && 'rbx' == RUBY_ENGINE
+if defined?(RUBY_ENGINE) && RUBY_ENGINE != 'ruby'
   # create dummy Makefile to indicate success
   f = File.open(File.join(File.dirname(__FILE__), "Makefile"), "w")
   f.write("all:\n\techo all\ninstall:\n\techo installed\n")

--- a/lib/debase.rb
+++ b/lib/debase.rb
@@ -2,6 +2,8 @@ if defined?(RUBY_ENGINE) && 'rbx' == RUBY_ENGINE
   require 'debase/rbx'
 elsif defined?(RUBY_ENGINE) && RUBY_ENGINE == 'truffleruby'
   require "debase/version"
+
+  Debugger = Module.new
   return
 else
   require "debase_internals"

--- a/lib/debase.rb
+++ b/lib/debase.rb
@@ -1,5 +1,8 @@
 if defined?(RUBY_ENGINE) && 'rbx' == RUBY_ENGINE
   require 'debase/rbx'
+elsif defined?(RUBY_ENGINE) && RUBY_ENGINE == 'truffleruby'
+  require "debase/version"
+  return
 else
   require "debase_internals"
 end


### PR DESCRIPTION
Related: https://github.com/ruby-debug/ruby-debug-ide/pull/240